### PR TITLE
Update Particle names to Minecraft 1.21.1 and update PlaceholderAPI dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,9 +28,6 @@
         <repository>
             <id>placeholderapi</id>
             <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
         </repository>
 
         <repository>
@@ -53,7 +50,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.20.4-R0.1-SNAPSHOT</version>
+            <version>1.21.1-R0.1-SNAPSHOT</version>
         </dependency>
         <!--<dependency>
             <groupId>org.openjdk.jmh</groupId>
@@ -105,7 +102,7 @@
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.10.10</version>
+            <version>2.11.6</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/su/nightexpress/nightcore/util/wrapper/UniParticle.java
+++ b/src/main/java/su/nightexpress/nightcore/util/wrapper/UniParticle.java
@@ -31,22 +31,22 @@ public class UniParticle {
 
     @NotNull
     public static UniParticle itemCrack(@NotNull ItemStack item) {
-        return new UniParticle(Particle.ITEM_CRACK, new ItemStack(item));
+        return new UniParticle(Particle.ITEM, new ItemStack(item));
     }
 
     @NotNull
     public static UniParticle itemCrack(@NotNull Material material) {
-        return new UniParticle(Particle.ITEM_CRACK, new ItemStack(material));
+        return new UniParticle(Particle.ITEM, new ItemStack(material));
     }
 
     @NotNull
     public static UniParticle blockCrack(@NotNull Material material) {
-        return new UniParticle(Particle.BLOCK_CRACK, material.createBlockData());
+        return new UniParticle(Particle.BLOCK, material.createBlockData());
     }
 
     @NotNull
     public static UniParticle blockDust(@NotNull Material material) {
-        return new UniParticle(Particle.BLOCK_DUST, material.createBlockData());
+        return new UniParticle(Particle.BLOCK, material.createBlockData());
     }
 
     @NotNull
@@ -61,7 +61,7 @@ public class UniParticle {
 
     @NotNull
     public static UniParticle redstone(@NotNull Color color, float size) {
-        return new UniParticle(Particle.REDSTONE, new Particle.DustOptions(color, size));
+        return new UniParticle(Particle.DUST, new Particle.DustOptions(color, size));
     }
 
     @NotNull


### PR DESCRIPTION
Hello,

I have updated the library for Minecraft 1.20.5+ particle names. I also noticed failing compilation due to outdated PlaceholderAPI dependency, so I bumped it.

Tested under 1.21.1 and confirmed working. Theoretically, backward compatibility can be achieved if you use reflection to look up the particle names.