### PR TITLE
Bump placeholderapi to 2.11.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.11.2</version>
+            <version>2.11.6</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
It seems as if PlaceholderAPI 2.11.2 has been removed from the repository. This PR fill fix building