### PR TITLE
Parse `%command_description%` placeholder in `Error.Command.Usage`

### DIFF
--- a/src/main/java/su/nightexpress/nightcore/command/experimental/node/DirectNode.java
+++ b/src/main/java/su/nightexpress/nightcore/command/experimental/node/DirectNode.java
@@ -104,7 +104,8 @@ public class DirectNode extends CommandNode implements DirectExecutor {
         if (parsedArguments.getArgumentMap().size() < this.requiredArguments) {
             return context.sendFailure(CoreLang.ERROR_COMMAND_USAGE.getMessage(this.plugin)
                 .replace(Placeholders.COMMAND_LABEL, this.getNameWithParents())
-                .replace(Placeholders.COMMAND_USAGE, this.getUsage()));
+                .replace(Placeholders.COMMAND_USAGE, this.getUsage())
+                .replace(Placeholders.COMMAND_DESCRIPTION, this.getDescription()));
         }
 
         if (!this.flags.isEmpty() && index < args.length) {


### PR DESCRIPTION
This allows for a bit more customizability in wrong usage messages. Tested with CoinsEngine's `/money send` command and works as described.