### PR TITLE
Add 'locale' to decimal formatter

### DIFF
--- a/src/main/java/su/nightexpress/nightcore/config/ConfigValue.java
+++ b/src/main/java/su/nightexpress/nightcore/config/ConfigValue.java
@@ -157,6 +157,14 @@ public class ConfigValue<T> {
     }
 
     @NotNull
+    public static ConfigValue<Locale> create(@NotNull String path, @NotNull Locale defaultValue, @Nullable String... description) {
+        Reader<Locale> reader = (cfg, path1, def) -> Objects.requireNonNullElse(Locale.forLanguageTag(cfg.getString(path1, def.toLanguageTag())), def);
+        Writer<Locale> writer = (cfg, path1, obj) -> cfg.set(path1, obj.toLanguageTag());
+
+        return create(path, reader, writer, defaultValue, description);
+    }
+
+    @NotNull
     public static <E extends Enum<E>> ConfigValue<E> create(@NotNull String path, @NotNull Class<E> clazz, @NotNull E defaultValue, @Nullable String... description) {
         Reader<E> reader = (cfg, path1, def) -> cfg.getEnum(path1, clazz, def);
         Writer<E> writer = (cfg, path1, obj) -> cfg.set(path1, obj.name());

--- a/src/main/java/su/nightexpress/nightcore/core/CoreConfig.java
+++ b/src/main/java/su/nightexpress/nightcore/core/CoreConfig.java
@@ -7,6 +7,7 @@ import su.nightexpress.nightcore.util.number.NumberShortcut;
 import su.nightexpress.nightcore.util.wrapper.UniFormatter;
 
 import java.math.RoundingMode;
+import java.util.Locale;
 import java.util.Map;
 
 public class CoreConfig {
@@ -69,7 +70,7 @@ public class CoreConfig {
 //        "[Default is false]");
 
     public static final ConfigValue<UniFormatter> NUMBER_FORMAT = ConfigValue.create("Number.Format",
-        UniFormatter.of("#,###.###", RoundingMode.HALF_EVEN),
+        UniFormatter.of("#,###.###", RoundingMode.HALF_EVEN, Locale.US),
         "Control over how numerical data is formatted and rounded.",
         "Allowed modes: " + StringUtil.inlineEnum(RoundingMode.class, ", "),
         "A tutorial can be found here: https://docs.oracle.com/javase/tutorial/i18n/format/decimalFormat.html"

--- a/src/main/java/su/nightexpress/nightcore/util/wrapper/UniFormatter.java
+++ b/src/main/java/su/nightexpress/nightcore/util/wrapper/UniFormatter.java
@@ -15,30 +15,33 @@ public class UniFormatter {
 
     private final String format;
     private final RoundingMode rounding;
+    private final Locale locale;
 
-    private UniFormatter(@NotNull String format, @NotNull RoundingMode rounding) {
+    private UniFormatter(@NotNull String format, @NotNull RoundingMode rounding, @NotNull Locale locale) {
         this.format = format;
         this.rounding = rounding;
-        this.formatter = new DecimalFormat(format, new DecimalFormatSymbols(Locale.US));
+        this.locale = locale;
+        this.formatter = new DecimalFormat(format, new DecimalFormatSymbols(locale));
         this.formatter.setRoundingMode(rounding);
     }
 
     @NotNull
-    public static UniFormatter of(@NotNull String format, @NotNull RoundingMode rounding) {
-        return new UniFormatter(format, rounding);
+    public static UniFormatter of(@NotNull String format, @NotNull RoundingMode rounding, @NotNull Locale locale) {
+        return new UniFormatter(format, rounding, locale);
     }
 
     @NotNull
     public static UniFormatter read(@NotNull FileConfig config, @NotNull String path) {
         String format = ConfigValue.create(path + ".Format", "#,###.##").read(config);
         RoundingMode rounding = ConfigValue.create(path + ".Rounding", RoundingMode.class, RoundingMode.HALF_EVEN).read(config);
-
-        return of(format, rounding);
+        Locale locale = ConfigValue.create(path + ".Locale", Locale.US).read(config);
+        return of(format, rounding, locale);
     }
 
     public void write(@NotNull FileConfig config, @NotNull String path) {
         config.set(path + ".Format", this.getFormat());
         config.set(path + ".Rounding", this.getRounding().name().toLowerCase());
+        config.set(path + ".Locale", this.locale.toLanguageTag());
     }
 
     public String getFormat() {


### PR DESCRIPTION
Some decimal formats don't actually work because it needs a specific locale.
```java
Number:
  Format:
    Format: '#.###,###'
    Rounding: half_even
```
This is an example for a `GERMAN` locale, which fails to load because the actual locale is `US`.
By adding `Locale: *locale*` it will actually set the decimal format to the specific locale.
The locale tag implements IETF BCP 47 which is composed of [RFC 4647 "Matching of Language Tags"](https://tools.ietf.org/html/rfc4647).

This will work:
```java
Number:
  Format:
    Format: '#.###,###'
    Rounding: half_even
    Locale: 'de-DE'
```