### PR TITLE
Fix UniParticle.redstone version-checking logic

### DIFF
--- a/src/main/java/su/nightexpress/nightcore/util/Version.java
+++ b/src/main/java/su/nightexpress/nightcore/util/Version.java
@@ -154,6 +154,10 @@ public enum Version {
         return getCurrent().isLower(version);
     }
 
+    public static boolean isBehindOrEqual(@NotNull Version version){
+        return getCurrent().isLower(version) || getCurrent() == version;
+    }
+
     public boolean isCurrent() {
         return this == Version.getCurrent();
     }

--- a/src/main/java/su/nightexpress/nightcore/util/wrapper/UniParticle.java
+++ b/src/main/java/su/nightexpress/nightcore/util/wrapper/UniParticle.java
@@ -69,7 +69,7 @@ public class UniParticle implements Writeable {
 
     @NotNull
     public static UniParticle redstone(@NotNull Color color, float size) {
-        Particle var = Version.isBehind(Version.MC_1_21_3) ? Particle.valueOf("REDSTONE") : BukkitThing.getParticle("dust");
+        Particle var = Version.isBehindOrEqual(Version.V1_20_R3) ? Particle.valueOf("REDSTONE") : BukkitThing.getParticle("dust");
         return new UniParticle(var, new Particle.DustOptions(color, size));
     }
 


### PR DESCRIPTION
**Fix version check for REDSTONE particle and add version helper**

The particle code in UniParticle.java (line 71) had a version check bug:
- It used REDSTONE particle when server version was older than 1.21.3
- But actually, REDSTONE was removed in 1.20.5+ servers, causing errors on newer versions

What changed:
Fixed version checks:
- Now correctly uses REDSTONE only for versions 1.20_R3 and older
- Uses dust particle for newer versions (1.20.5+)  

Added a clearer isBehindOrEqual() method in Version.java for version comparisons