### PR TITLE
feat: optional debit account for Vault integration

### DIFF
--- a/main/src/main/java/su/nightexpress/nightcore/core/CoreConfig.java
+++ b/main/src/main/java/su/nightexpress/nightcore/core/CoreConfig.java
@@ -9,8 +9,11 @@ import su.nightexpress.nightcore.util.wrapper.UniFormatter;
 
 import java.math.RoundingMode;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.UUID;
+import java.util.function.Supplier;
 
 public class CoreConfig {
 
@@ -34,6 +37,24 @@ public class CoreConfig {
     public static final ConfigValue<Boolean> ECONOMY_PLACEHOLDERS_API_FORMAT = ConfigValue.create("Integrations.Economy.PlaceholderAPI_In_Format",
         true,
         "Whether to apply " + PAPI.NAME + " placeholders in currency's Format setting."
+    );
+
+    public static final ConfigValue<Optional<UUID>> VAULT_DEBIT_ACCOUNT = ConfigValue.create(
+        "Integrations.Economy.Vault.DebitAccount",
+        (config, path) -> {
+            String raw = config.getString(path);
+            if (raw == null || raw.isBlank()) return Optional.empty();
+            try {
+                return Optional.of(UUID.fromString(raw.trim()));
+            } catch (IllegalArgumentException ignored) {
+                return Optional.empty();
+            }
+        },
+        (config, path, value) -> config.set(path, value.map(UUID::toString).orElse("")),
+        (Supplier<Optional<UUID>>) Optional::empty,
+        "Optional Vault account (UUID) to debit from instead of the payer when processing economy payments.",
+        "Leave empty to charge the payer as usual. Uses UUID only; do not use player names.",
+        "When set, the plugin that performs the payment should check this account's balance (e.g. hasEnough) before depositing and is responsible for notifying players if insufficient."
     );
 
     public static final ConfigValue<Set<String>> ITEMS_DISABLED_PROVIDERS = ConfigValue.create("Integrations.Items.DisabledProviders",

--- a/main/src/main/java/su/nightexpress/nightcore/integration/currency/EconomyBridge.java
+++ b/main/src/main/java/su/nightexpress/nightcore/integration/currency/EconomyBridge.java
@@ -6,6 +6,7 @@ import org.jspecify.annotations.NonNull;
 import su.nightexpress.nightcore.bridge.currency.Currency;
 import su.nightexpress.nightcore.bridge.currency.EconomyBridgeAPI;
 import su.nightexpress.nightcore.bridge.registry.NightRegistry;
+import su.nightexpress.nightcore.core.CoreConfig;
 import su.nightexpress.nightcore.integration.currency.impl.DummyCurrency;
 
 import java.util.Optional;
@@ -111,12 +112,26 @@ public class EconomyBridge {
 
     @Deprecated(forRemoval = true)
     public static boolean deposit(@NonNull Player player, @NonNull String id, double amount) {
-        deposit(player.getUniqueId(), id, amount);
-        return true;
+        return deposit(player.getUniqueId(), id, amount);
     }
 
     @Deprecated(forRemoval = true)
     public static boolean deposit(@NonNull UUID playerId, @NonNull String id, double amount) {
+        if (CurrencyId.VAULT.equals(id)) {
+            Optional<UUID> debitAccountId = getVaultDebitAccountId();
+            if (debitAccountId.isPresent()) {
+                Currency currency = getCurrency(id);
+                if (currency == null) return false;
+
+                UUID debitId = debitAccountId.get();
+                if (getBalance(debitId, id) < amount) return false;
+
+                currency.take(debitId, amount);
+                currency.give(playerId, amount);
+                return true;
+            }
+        }
+
         api.deposit(playerId, id, amount);
         return true;
     }
@@ -168,7 +183,31 @@ public class EconomyBridge {
         return true;
     }
 
+    /**
+     * When a plugin uses a separate Vault account to pay from (see CoreConfig VAULT_DEBIT_ACCOUNT),
+     * use this to resolve the account to debit. If none is set, the payer is charged as usual.
+     * When {@link #deposit(UUID, String, double)} returns false and this is present, the debit account
+     * had insufficient balance; the caller is responsible for notifying players when appropriate.
+     *
+     * @return Optional UUID of the account to debit for Vault economy; empty if the payer should be charged.
+     */
+    @NotNull
+    public static Optional<UUID> getVaultDebitAccountId() {
+        return CoreConfig.VAULT_DEBIT_ACCOUNT.get();
+    }
 
+    /**
+     * Resolves the account to debit for a Vault economy payment: the configured debit account if set,
+     * otherwise the payer. Use this before {@link #hasEnough(UUID, String, double)} and
+     * {@link #withdraw(UUID, String, double)} so the correct account is checked and charged.
+     *
+     * @param payerId the player initiating the payment (used when no debit account is configured).
+     * @return UUID of the account to debit.
+     */
+    @NotNull
+    public static UUID getVaultDebitAccountIdOrPayer(@NotNull UUID payerId) {
+        return getVaultDebitAccountId().orElse(payerId);
+    }
 
     @Deprecated(forRemoval = true)
     public static boolean hasCurrency() {

--- a/main/src/main/java/su/nightexpress/nightcore/integration/currency/EconomyBridge.java
+++ b/main/src/main/java/su/nightexpress/nightcore/integration/currency/EconomyBridge.java
@@ -117,21 +117,6 @@ public class EconomyBridge {
 
     @Deprecated(forRemoval = true)
     public static boolean deposit(@NonNull UUID playerId, @NonNull String id, double amount) {
-        if (CurrencyId.VAULT.equals(id)) {
-            Optional<UUID> debitAccountId = getVaultDebitAccountId();
-            if (debitAccountId.isPresent()) {
-                Currency currency = getCurrency(id);
-                if (currency == null) return false;
-
-                UUID debitId = debitAccountId.get();
-                if (getBalance(debitId, id) < amount) return false;
-
-                currency.take(debitId, amount);
-                currency.give(playerId, amount);
-                return true;
-            }
-        }
-
         api.deposit(playerId, id, amount);
         return true;
     }

--- a/main/src/main/java/su/nightexpress/nightcore/integration/currency/EconomyBridge.java
+++ b/main/src/main/java/su/nightexpress/nightcore/integration/currency/EconomyBridge.java
@@ -191,7 +191,7 @@ public class EconomyBridge {
      *
      * @return Optional UUID of the account to debit for Vault economy; empty if the payer should be charged.
      */
-    @NotNull
+    @NonNull
     public static Optional<UUID> getVaultDebitAccountId() {
         return CoreConfig.VAULT_DEBIT_ACCOUNT.get();
     }
@@ -204,8 +204,8 @@ public class EconomyBridge {
      * @param payerId the player initiating the payment (used when no debit account is configured).
      * @return UUID of the account to debit.
      */
-    @NotNull
-    public static UUID getVaultDebitAccountIdOrPayer(@NotNull UUID payerId) {
+    @NonNull
+    public static UUID getVaultDebitAccountIdOrPayer(@NonNull UUID payerId) {
         return getVaultDebitAccountId().orElse(payerId);
     }
 

--- a/main/src/main/java/su/nightexpress/nightcore/integration/currency/impl/VaultEconomyCurrency.java
+++ b/main/src/main/java/su/nightexpress/nightcore/integration/currency/impl/VaultEconomyCurrency.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Player;
 import org.jspecify.annotations.NonNull;
 import su.nightexpress.nightcore.integration.currency.CurrencyId;
 import su.nightexpress.nightcore.integration.currency.CurrencySettings;
+import su.nightexpress.nightcore.integration.currency.EconomyBridge;
 import su.nightexpress.nightcore.integration.currency.type.IncompleteCurrency;
 import su.nightexpress.nightcore.util.Placeholders;
 import su.nightexpress.nightcore.util.ServerUtils;
@@ -81,6 +82,23 @@ public class VaultEconomyCurrency extends IncompleteCurrency {
     @Override
     protected void depositDirect(@NonNull Player player, double amount) {
         this.economy().ifPresent(economy -> economy.depositPlayer(player, amount));
+    }
+
+    @Override
+    public void give(@NonNull Player player, double amount) {
+        this.give(player.getUniqueId(), amount);
+    }
+
+    @Override
+    public void give(@NonNull UUID playerId, double amount) {
+        Optional<UUID> debitAccountId = EconomyBridge.getVaultDebitAccountId();
+        if (debitAccountId.isPresent()) {
+            UUID debitId = debitAccountId.get();
+            if (this.getBalance(debitId) < amount) return;
+            this.take(debitId, amount);
+        }
+
+        this.economy().ifPresent(economy -> economy.depositPlayer(Bukkit.getOfflinePlayer(playerId), amount));
     }
 
     @Override


### PR DESCRIPTION
This feature allows payments made in Vault currency to originate from a Vault account, specified by UUID.