### PR TITLE
Fix root command node permission enforcement

### DIFF
--- a/main/src/main/java/su/nightexpress/nightcore/commands/command/AbstractCommand.java
+++ b/main/src/main/java/su/nightexpress/nightcore/commands/command/AbstractCommand.java
@@ -127,13 +127,6 @@ public abstract class AbstractCommand<N extends ExecutableNode> extends Command 
 
         if (reader.canMoveForward()) {
             for (CommandNode child : node.getRelevantNodes(reader)) {
-                if (!child.hasPermission(sender)) {
-                    if (forExecution) {
-                        CoreLang.ERROR_NO_PERMISSION.withPrefix(this.plugin).send(sender);
-                    }
-                    return null;
-                }
-
                 return this.parseNodes(child, reader, builder, forExecution);
             }
         }
@@ -150,6 +143,13 @@ public abstract class AbstractCommand<N extends ExecutableNode> extends Command 
     }
 
     private boolean testRequirements(@NonNull CommandSender sender, @NonNull CommandNode node, boolean forExecution) {
+        if (!node.hasPermission(sender)) {
+            if (forExecution) {
+                CoreLang.ERROR_NO_PERMISSION.withPrefix(this.plugin).send(sender);
+            }
+            return false;
+        }
+
         for (CommandRequirement requirement : node.getRequirements()) {
             if (!requirement.test(sender)) {
                 if (forExecution) {

--- a/main/src/main/java/su/nightexpress/nightcore/commands/tree/HubNode.java
+++ b/main/src/main/java/su/nightexpress/nightcore/commands/tree/HubNode.java
@@ -82,7 +82,12 @@ public class HubNode extends ExecutableNode {
 
     @Override
     public void suggests(@NotNull ArgumentReader reader, @NotNull CommandContext context, @NotNull Suggestions suggestions) {
-        suggestions.setSuggestions(new ArrayList<>(this.children.keySet()));
+        CommandSender sender = context.getSender();
+
+        suggestions.setSuggestions(this.children.values().stream()
+            .filter(child -> child.hasPermission(sender))
+            .map(CommandNode::getName)
+            .toList());
     }
 
     @Override


### PR DESCRIPTION
NightCore command nodes can define permissions, but `AbstractCommand` only checks child node permissions while parsing. The current/root node permission is not enforced before the node parses or executes.

This means a root command such as `/vanish`, where SunLight attaches `sunlight.vanish.command.vanish` to the root node, can execute even when that permission is denied by LuckPerms.

This patch makes current node permission checks part of the normal node validation path, so root and nested node permissions are handled consistently. Tab completion remains silent and inaccessible command paths are filtered.