### PR TITLE
Fix Paper 26.1+ GUI menu compatibility

### DIFF
--- a/main/src/main/java/su/nightexpress/nightcore/menu/impl/AbstractMenu.java
+++ b/main/src/main/java/su/nightexpress/nightcore/menu/impl/AbstractMenu.java
@@ -178,12 +178,6 @@ public abstract class AbstractMenu<P extends NightCorePlugin> implements Menu {
             this.purgeViewer(player);
             return false;
         }
-        if (inventory.getType() == InventoryType.CRAFTING) {
-            this.plugin.warn("Got CRAFTING inventory when trying to open " + this.getClass().getSimpleName() +
-                " menu for '" + player.getName() + "'.");
-            this.purgeViewer(player);
-            return false;
-        }
 
         this.getItems(viewer).forEach(menuItem -> {
             ItemStack item = menuItem.getItemStack();

--- a/main/src/main/java/su/nightexpress/nightcore/ui/inventory/menu/AbstractMenuBase.java
+++ b/main/src/main/java/su/nightexpress/nightcore/ui/inventory/menu/AbstractMenuBase.java
@@ -477,6 +477,8 @@ public abstract class AbstractMenuBase implements Menu, LangContainer {
 
     @Override
     public void handleClick(@NonNull Player player, @NonNull InventoryClickEvent event) {
+        event.setCancelled(true);
+        event.setCancelled(true);
         MenuViewer viewer = this.getViewer(player);
         if (viewer == null) return;
 


### PR DESCRIPTION
Fixes two issues that prevent inventory GUIs from functioning correctly on Paper 26.1+ (Minecraft 26.1.2 / Purpur 26.1.2+).

## Fix 1: `handleClick()` never cancels InventoryClickEvent

**File**: `AbstractMenuBase.java` (`ui/inventory/menu/`)

The new UI system `handleClick()` method processes clicks but never calls `event.setCancelled(true)`. On Paper 26.1+, `MenuType`-based inventory views do NOT automatically lock items. Without this:
- Players can drag GUI items (glass panes, buttons, products) into their own inventory
- Functional button clicks are not reliably intercepted

**Fix**: Add `event.setCancelled(true)` as the first line of `handleClick()`.

## Fix 2: False-positive `InventoryType.CRAFTING` check

**File**: `AbstractMenu.java` (`menu/impl/`)

`open()` checks `inventory.getType() == InventoryType.CRAFTING` and returns `false` if true. On Paper 26.1+, `Bukkit.createInventory(null, size, title)` returns an inventory whose `getType()` now reports `CRAFTING` because the legacy `CHEST` type was removed at the protocol level. This causes menu registration to silently fail.

**Fix**: Remove the CRAFTING type guard.

## Bonus finding (not fixed here)

`GradientTagHandler` throws NPE when encountering `<gradient:#c1>text</gradient:#c2>`. `colorStops` is null at `onHandleClose`.

## Tested on

- Purpur 26.1.2 (Paper API 26.1.2)
- nightcore 2.16.0 + ExcellentShop 5.1.1