### PR TITLE
Fix nullable skin URL loading

### DIFF
--- a/main/src/main/java/su/nightexpress/nightcore/userdata/UserDataQueries.java
+++ b/main/src/main/java/su/nightexpress/nightcore/userdata/UserDataQueries.java
@@ -20,7 +20,7 @@ public class UserDataQueries {
     public static final RowMapper<UserData> USER_ROW_MAPPER = resultSet -> {
         UUID userId = USER_ID_COLUMN.readOrThrow(resultSet);
         String userName = USER_NAME_COLUMN.readOrThrow(resultSet);
-        String lastSkinUrl = LAST_SKIN_COLUMN.readOrThrow(resultSet);
+        String lastSkinUrl = LAST_SKIN_COLUMN.read(resultSet).orElse(null);
         long lastSeen = LAST_SEEN_COLUMN.readOrThrow(resultSet);
 
         UserData data = new UserData(userId, userName);


### PR DESCRIPTION
## Summary

- read the nullable `last_skin_url` column without throwing when its SQL value is `NULL`
- preserve `null` for players without a cached skin URL
- prevent `NoSuchElementException` from interrupting `AsyncPlayerPreLoginEvent`

## Rationale

`LAST_SKIN_COLUMN` is declared with `.nullable()`, `UserData#getLastSkinUrl()` is annotated `@Nullable`, and `UserData#refreshProfile()` already handles a missing skin URL. Using `readOrThrow()` for this column contradicts those contracts.

## Verification

- compiled the changed class with `javac --release 21` against NightCore 2.16.1
- verified the generated bytecode uses `Column.read(...).orElse(null)` only for `LAST_SKIN_COLUMN`
- tested on Paper with an existing SQLite user row whose `last_skin_url` remained `NULL`; pre-login completed without the NightCore exception
- `mvn -B test` successfully built `utils`, `bridge`, `paper`, `spigot`, and `intergration-placeholderapi`; the `main` module could not resolve NightExpress-hosted dependencies because `repo.nightexpressdev.com` timed out

Fixes #87